### PR TITLE
docs: add code of conduct files

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We, as members, contributors and leaders, are committed to making participation
+in our community a harassment-free experience for everyone, regardless of age,
+personal appearance, body size, visible or invisible disability, national
+origin, ethnicity, race, caste, color, religion, sexual characteristics, gender
+identity and expression, sexual orientation, experience level, education or
+socioeconomic status.
+
+We are committed to acting and interacting in ways that contribute to an open,
+welcoming, diverse, inclusive and healthy community.
+
+## Our Standards
+
+Examples of behaviors that contribute to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior they deem inappropriate, threatening, offensive or
+harmful.
+
+Community leaders have the right and responsibility to remove, edit or reject
+comments, commits, codes, wiki edits, issues and other contributions that do not
+align with this Code of Conduct and will communicate the reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies to all community spaces and also applies when an
+individual officially represents the community in public spaces. Examples of
+representing our community include using an official email address, posting
+through an official social media account, or acting as a named representative at
+an online or offline event.
+
+## Enforcement
+
+Cases of abusive, harassing or otherwise unacceptable behavior may be reported
+by contacting limapaulobsb@gmail.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate under the circumstances. Our team will maintain confidentiality
+regarding the reporter of an incident. Enforcement may result in a permanent ban
+from all official communication channels or other actions deemed appropriate.
+
+Maintainers who fail to follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of
+project leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/translations/CODE_OF_CONDUCT_PT_BR.md
+++ b/docs/translations/CODE_OF_CONDUCT_PT_BR.md
@@ -1,0 +1,86 @@
+# Código de Conduta
+
+## Nossa promessa
+
+Nós, como membros, colaboradores e líderes, nos comprometemos a tornar a
+participação em nossa comunidade uma experiência livre de assédio para todos,
+independentemente de idade, aparência pessoal, tamanho do corpo, deficiência
+visível ou invisível, nacionalidade, etnia, raça, casta, cor, religião,
+características sexuais, identidade e expressão de gênero, orientação sexual,
+nível de experiência, educação ou status socioeconômico.
+
+Comprometemo-nos a agir e interagir de forma a contribuir para uma comunidade
+aberta, acolhedora, diversa, inclusiva e saudável.
+
+## Nossos padrões
+
+Exemplos de comportamentos que contribuem para um ambiente positivo para nossa
+comunidade incluem:
+
+- Demonstrar empatia e bondade para com outras pessoas
+- Ser respeitoso com as diferentes opiniões, pontos de vista e experiências
+- Dar e aceitar gentilmente um _feedback_ construtivo
+- Aceitar a responsabilidade e pedir desculpas aos afetados por nossos erros, e
+  aprender com a experiência
+- Focar no que é melhor não apenas para nós como indivíduos, mas para a
+  comunidade em geral
+
+Exemplos de comportamento inaceitável incluem:
+
+- O uso de linguagem ou imagens sexualizadas e assédio sexual de qualquer tipo
+- Comentários insultuosos ou depreciativos e ataques pessoais ou políticos
+- Assédio público ou privado
+- Publicar informações privadas de outras pessoas, como um endereço físico ou de
+  e-mail, sem sua permissão explícita
+- Outra conduta que normalmente é considerada inadequada em um ambiente
+  profissional
+
+## Nossa responsabilidade
+
+Os líderes da comunidade são responsáveis por esclarecer e fazer cumprir nossos
+padrões de comportamento e tomarão medidas corretivas apropriadas e justas em
+resposta a qualquer comportamento que considerem inapropriado, ameaçador,
+ofensivo ou prejudicial.
+
+Os líderes da comunidade têm o direito e a responsabilidade de remover, editar
+ou rejeitar comentários, _commits_, código, edições na wiki, _Issues_ e outras
+contribuições que não estejam alinhadas com este Código de Conduta e comunicarão
+os motivos das decisões de moderação quando apropriado.
+
+## Escopo
+
+Este Código de Conduta se aplica a todos os espaços comunitários e também se
+aplica quando um indivíduo representa oficialmente a comunidade em espaços
+públicos. Exemplos de representação de nossa comunidade incluem o uso de um
+endereço de e-mail oficial, postagem por meio de uma conta de mídia social
+oficial ou atuar como representante em um evento online ou offline.
+
+## Aplicação
+
+Casos de comportamento abusivo, assediante ou de outra forma inaceitável podem
+ser denunciados pelo e-mail limapaulobsb@gmail.com. Todas as reclamações serão
+analisadas e investigadas e resultarão em uma resposta que seja considerada
+necessária e apropriada às circunstâncias. Nossa equipe manterá a
+confidencialidade em relação ao relator de um incidente. A aplicação pode
+resultar em banimento permanente de todos os canais de comunicação oficiais ou
+outras ações consideradas apropriadas.
+
+Os mantenedores que não seguirem ou fizerem cumprir o Código de Conduta de
+boa-fé podem enfrentar repercussões temporárias ou permanentes conforme
+determinado por outros membros da liderança do projeto.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage],
+versão 2.1, disponível em
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Para obter respostas a perguntas comuns sobre este código de conduta, veja a
+página de Perguntas Frequentes (FAQ) em
+[https://www.contributor-covenant.org/faq][FAQ]. Traduções estão disponíveis em
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Description
Add the Code of Conduct, which is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), and its pt-BR translation.